### PR TITLE
feat(v4): upgrade corenlp to v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.exist-db</groupId>
   <artifactId>stanford-nlp</artifactId>
-  <version>0.6.0-SNAPSHOT</version>
+  <version>0.7.0-SNAPSHOT</version>
 
   <name>Stanford Natural Language Processing</name>
   <description>Integrates the Stanford CoreNLP annotation pipeline library into eXist-db.</description>
@@ -64,7 +64,7 @@
     <exist.version>5.0.0</exist.version>
     <node.version>v12.22.1</node.version>
     <npm.version>7.9.0</npm.version>
-    <corenlp.version>3.9.2</corenlp.version>
+    <corenlp.version>4.2.0</corenlp.version>
     <!-- See polymer-cli documentation -->
     <browser.support>es5-bundled</browser.support>
 

--- a/src/main/polymer/package-lock.json
+++ b/src/main/polymer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "polymer-starter-kit",
-  "version": "0.6.0-SNAPSHOT",
+  "version": "0.7.0-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "polymer-starter-kit",
-      "version": "0.6.0-SNAPSHOT",
+      "version": "0.7.0-SNAPSHOT",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@polymer/app-layout": "^3.1.0",

--- a/src/main/polymer/package.json
+++ b/src/main/polymer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-starter-kit",
-  "version": "0.6.0-SNAPSHOT",
+  "version": "0.7.0-SNAPSHOT",
   "description": "A starting point for Polymer apps",
   "author": "The Polymer Authors",
   "license": "BSD-3-Clause",

--- a/src/main/xar-resources/modules/load-language.xqm
+++ b/src/main/xar-resources/modules/load-language.xqm
@@ -8,6 +8,7 @@ import module namespace console = "http://exist-db.org/xquery/console";
 import module namespace functx = "http://www.functx.com";
 import module namespace util = "http://exist-db.org/xquery/util";
 import module namespace map = "http://www.w3.org/2005/xpath-functions/map";
+import module namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 declare function ll:mkcol-recursive($collection, $components) {
     if (exists($components)) then

--- a/src/main/xar-resources/modules/load-languages.xq
+++ b/src/main/xar-resources/modules/load-languages.xq
@@ -1,16 +1,17 @@
 xquery version "3.1";
 
 import module namespace ll = "http://exist-db.org/xquery/stanford-nlp/load-language" at "load-language.xqm";
+import module namespace config = "http://exist-db.org/apps/stanford-nlp/config";
 
 
 let $paths := (
-            "http://nlp.stanford.edu/software/stanford-english-corenlp-2018-10-05-models.jar",
-            "http://nlp.stanford.edu/software/stanford-english-kbp-corenlp-2018-10-05-models.jar",
-            "http://nlp.stanford.edu/software/stanford-arabic-corenlp-2018-10-05-models.jar",
-            "http://nlp.stanford.edu/software/stanford-chinese-corenlp-2018-10-05-models.jar",
-            "http://nlp.stanford.edu/software/stanford-french-corenlp-2018-10-05-models.jar",
-            "http://nlp.stanford.edu/software/stanford-german-corenlp-2018-10-05-models.jar",
-            "http://nlp.stanford.edu/software/stanford-spanish-corenlp-2018-10-05-models.jar",
+            $config:corenlp-model-url || "arabic.jar",
+            $config:corenlp-model-url || "chinese.jar",
+            $config:corenlp-model-url || "english.jar",
+            $config:corenlp-model-url || "english-kbp.jar",
+            $config:corenlp-model-url || "french.jar",
+            $config:corenlp-model-url || "german.jar",
+            $config:corenlp-model-url || "spanish.jar",
             ()
         )
 

--- a/src/main/xar-resources/modules/schedule-language.xq
+++ b/src/main/xar-resources/modules/schedule-language.xq
@@ -1,7 +1,8 @@
 xquery version "3.1";
 
 import module namespace scheduler = "http://exist-db.org/xquery/scheduler";
+import module namespace config = "http://exist-db.org/apps/stanford-nlp/config";
 
-let $param := <parameters><param name="path" value="http://nlp.stanford.edu/software/stanford-chinese-corenlp-2018-10-05-models.jar"/></parameters>
+let $param := <parameters><param name="path" value="{$config:corenlp-model-url || 'chinese.jar'}"/></parameters>
 
 return scheduler:schedule-xquery-periodic-job("/db/apps/stanford-nlp/module/schedule-load.xq", 500, "load chinese", $param, 500, 0)

--- a/src/main/xar-resources/modules/schedule-load.xq
+++ b/src/main/xar-resources/modules/schedule-load.xq
@@ -1,7 +1,8 @@
 xquery version "3.1";
 
 import module namespace ll = "http://exist-db.org/xquery/stanford-nlp/load-language" at "load-language.xqm";
+import module namespace config = "http://exist-db.org/apps/stanford-nlp/config";
 
-declare variable $local:path external := "http://nlp.stanford.edu/software/stanford-english-corenlp-2018-10-05-models.jar";
+declare variable $local:path external := $config:corenlp-model-url || 'english.jar';
 
 ll:process($local:path)

--- a/src/main/xquery/config.xqm
+++ b/src/main/xquery/config.xqm
@@ -33,8 +33,11 @@ declare variable $config:repo-descriptor := doc(concat($config:app-root, "/repo.
 
 declare variable $config:expath-descriptor := doc(concat($config:app-root, "/expath-pkg.xml"))/expath:package;
 
-
 declare variable $config:data-root := concat($config:app-root, "/data");
+
+(: TODO(DP): use maven templating to construct version here :)
+declare variable $config:corenlp-version := '4.2.0';
+declare variable $config:corenlp-model-url := 'http://nlp.stanford.edu/software/stanford-corenlp-' || $config:corenlp-version ||'-models-';
 
 (:~
  : Resolve the given path using the current application context.

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -69,24 +69,24 @@
         <dependencySet>
             <groupId>edu.stanford.nlp</groupId>
             <artifactId>stanford-corenlp</artifactId>
-            <version>3.9.2</version>
+            <version>${corenlp.version}</version>
         </dependencySet>
         <dependencySet>
             <groupId>edu.stanford.nlp</groupId>
             <artifactId>stanford-corenlp</artifactId>
-            <version>3.9.2</version>
+            <version>${corenlp.version}</version>
             <classifier>models</classifier>
         </dependencySet>
 <!--        <dependencySet>-->
 <!--            <groupId>edu.stanford.nlp</groupId>-->
 <!--            <artifactId>stanford-corenlp</artifactId>-->
-<!--            <version>3.9.2</version>-->
+<!--            <version>${corenlp.version}</version>-->
 <!--            <classifier>models-english</classifier>-->
 <!--        </dependencySet>-->
 <!--        <dependencySet>-->
 <!--            <groupId>edu.stanford.nlp</groupId>-->
 <!--            <artifactId>stanford-corenlp</artifactId>-->
-<!--            <version>3.9.2</version>-->
+<!--            <version>${corenlp.version}</version>-->
 <!--            <classifier>models-english-kbp</classifier>-->
 <!--        </dependencySet>-->
         <dependencySet>


### PR DESCRIPTION
Updates the core libraries to v 4.2.0 see https://github.com/lcahlander/exist-stanford-nlp/issues/10

tested and working

we could make this more efficient by using maven's templating to updated the version inside `config.xqm`